### PR TITLE
Project loading now refreshes the page

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-loader-spinner": "^4.0.0",
     "react-promise-tracker": "^2.1.0",
     "react-redux": "^7.2.6",
+    "react-router-dom": "^6.9.0",
     "react-vega": "^7.6.0",
     "redux": "^4.1.2",
     "visyn_core": "git+ssh://git@github.com/datavisyn/visyn_core#develop",

--- a/src/LineUpContext/LineUpContext.tsx
+++ b/src/LineUpContext/LineUpContext.tsx
@@ -769,7 +769,7 @@ export const LineUpContext = connector(function ({
       });
 
       const lineupSmilesCols = ranking.children.filter((x: any) => smilesStructureColumns.includes(x.label)) as StructureImageColumn[];
-      console.log(lineupSmilesCols);
+      // (lineupSmilesCols);
       lineupSmilesCols.forEach((lineup_smiles_col) => {
         lineup_smiles_col.on('widthChanged', (prev, current) => {
           lineup.update();

--- a/src/Overrides/Dataset/DatasetTabPanel.tsx
+++ b/src/Overrides/Dataset/DatasetTabPanel.tsx
@@ -107,12 +107,6 @@ export const DatasetTabPanel = connector(({ onDataSelected, resetViews, setTrigg
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
-      {/* <Box paddingLeft={2} paddingTop={2}>
-        <Typography variant="subtitle2" gutterBottom>
-          Saved datasets
-        </Typography>
-      </Box> */}
-
       <UploadedFiles
         onChange={(entry) => {
           triggerUpdate(entry);
@@ -138,12 +132,6 @@ export const DatasetTabPanel = connector(({ onDataSelected, resetViews, setTrigg
         }}
       />
 
-      {/* <Box paddingLeft={2} paddingTop={2}>
-        <Typography variant="subtitle2" gutterBottom>
-          Upload new dataset
-        </Typography>
-      </Box> */}
-
       {!clientConfig.publicVersion ? (
         <DatasetDrop
           onDatasetChange={(dataset) => {
@@ -154,10 +142,6 @@ export const DatasetTabPanel = connector(({ onDataSelected, resetViews, setTrigg
           abort_controller={abortController}
         />
       ) : null}
-
-      {/* <Box paddingTop={2} paddingX={2}>
-        <Divider orientation="horizontal" />
-      </Box> */}
 
       {!clientConfig.publicVersion ? (
         <Box paddingLeft={2} paddingTop={2} paddingRight={2}>

--- a/src/Overrides/Dataset/UploadedFiles.tsx
+++ b/src/Overrides/Dataset/UploadedFiles.tsx
@@ -7,6 +7,7 @@ import { trackPromise } from 'react-promise-tracker';
 import { ISecureItem, userSession, useVisynAppContext } from 'visyn_core';
 import { ReactionCIMEBackendFromEnv } from '../../Backend/ReactionCIMEBackend';
 import { LoadingIndicatorView } from './LoadingIndicatorDialog';
+import { Link } from 'react-router-dom';
 
 const textOverflowStyle = {
   textOverflow: 'ellipsis',
@@ -37,10 +38,6 @@ export function UploadedFiles({ onChange, refresh }) {
     updateFiles();
     // eslint-disable-next-line
   }, [refresh]);
-
-  const handleClick = (entry) => {
-    onChange(entry);
-  };
 
   const handleDelete = (file: string) => {
     cancellablePromise(ReactionCIMEBackendFromEnv.deleteFile(file))
@@ -90,7 +87,8 @@ export function UploadedFiles({ onChange, refresh }) {
                 />
                 {!clientConfig.publicVersion && userSession.canWrite(file) && (
                   <ListItemSecondaryAction
-                    onClick={() => {
+                    onClick={(event) => {
+                      event.preventDefault();
                       handleDelete(file.id);
                     }}
                   >

--- a/src/Overrides/Dataset/UploadedFiles.tsx
+++ b/src/Overrides/Dataset/UploadedFiles.tsx
@@ -77,14 +77,6 @@ export function UploadedFiles({ onChange, refresh }) {
                 href={`?project=${file.id}`}
                 component="a"
                 target="_self"
-                /** onClick={() => {
-                  handleClick({
-                    display: file.name,
-                    path: file.id,
-                    type: DatasetType.Chem,
-                    uploaded: true,
-                  });
-                }} */
               >
                 <ListItemText
                   primary={file.name}

--- a/src/Overrides/Dataset/UploadedFiles.tsx
+++ b/src/Overrides/Dataset/UploadedFiles.tsx
@@ -7,7 +7,6 @@ import { trackPromise } from 'react-promise-tracker';
 import { ISecureItem, userSession, useVisynAppContext } from 'visyn_core';
 import { ReactionCIMEBackendFromEnv } from '../../Backend/ReactionCIMEBackend';
 import { LoadingIndicatorView } from './LoadingIndicatorDialog';
-import { Link } from 'react-router-dom';
 
 const textOverflowStyle = {
   textOverflow: 'ellipsis',

--- a/src/Overrides/Dataset/UploadedFiles.tsx
+++ b/src/Overrides/Dataset/UploadedFiles.tsx
@@ -67,7 +67,7 @@ export function UploadedFiles({ onChange, refresh }) {
             <LoadingIndicatorView area={loadingArea} />
 
             {files.map((file) => (
-              <ListItemButton key={file.id} data-cy="uploaded-data-list-item" href={`?project=${file.id}`} component="a" target="_self">
+              <ListItemButton key={file.id} data-cy="uploaded-data-list-item" href={`/?project=${file.id}`} component="a" target="_self">
                 <ListItemText
                   primary={file.name}
                   secondary={`By ${file.creator}`}

--- a/src/Overrides/Dataset/UploadedFiles.tsx
+++ b/src/Overrides/Dataset/UploadedFiles.tsx
@@ -1,6 +1,6 @@
-import { Box, Button, IconButton, List, ListItem, ListItemButton, ListItemSecondaryAction, ListItemText, Tooltip, Typography } from '@mui/material';
+import { Box, Button, IconButton, List, ListItemButton, ListItemSecondaryAction, ListItemText, Tooltip, Typography } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { DatasetType, useCancellablePromise } from 'projection-space-explorer';
+import { useCancellablePromise } from 'projection-space-explorer';
 import React, { CSSProperties } from 'react';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import { trackPromise } from 'react-promise-tracker';
@@ -8,11 +8,11 @@ import { ISecureItem, userSession, useVisynAppContext } from 'visyn_core';
 import { ReactionCIMEBackendFromEnv } from '../../Backend/ReactionCIMEBackend';
 import { LoadingIndicatorView } from './LoadingIndicatorDialog';
 
-const textOverflowStyle = {
+const textOverflowStyle: CSSProperties = {
   textOverflow: 'ellipsis',
   overflow: 'hidden',
   whiteSpace: 'nowrap',
-} satisfies CSSProperties;
+};
 
 const loadingArea = 'update_uploaded_files_list';
 export function UploadedFiles({ onChange, refresh }) {
@@ -67,13 +67,7 @@ export function UploadedFiles({ onChange, refresh }) {
             <LoadingIndicatorView area={loadingArea} />
 
             {files.map((file) => (
-              <ListItemButton
-                key={file.id}
-                data-cy="uploaded-data-list-item"
-                href={`?project=${file.id}`}
-                component="a"
-                target="_self"
-              >
+              <ListItemButton key={file.id} data-cy="uploaded-data-list-item" href={`?project=${file.id}`} component="a" target="_self">
                 <ListItemText
                   primary={file.name}
                   secondary={`By ${file.creator}`}

--- a/src/Overrides/Dataset/UploadedFiles.tsx
+++ b/src/Overrides/Dataset/UploadedFiles.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, IconButton, List, ListItem, ListItemSecondaryAction, ListItemText, Tooltip, Typography } from '@mui/material';
+import { Box, Button, IconButton, List, ListItem, ListItemButton, ListItemSecondaryAction, ListItemText, Tooltip, Typography } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { DatasetType, useCancellablePromise } from 'projection-space-explorer';
 import React, { CSSProperties } from 'react';
@@ -69,19 +69,22 @@ export function UploadedFiles({ onChange, refresh }) {
             style={{ backgroundColor: 'white', border: '1px solid lightgrey', borderRadius: '4px', overflowY: 'auto', maxHeight: '400px' }}
           >
             <LoadingIndicatorView area={loadingArea} />
+
             {files.map((file) => (
-              <ListItem
+              <ListItemButton
                 key={file.id}
                 data-cy="uploaded-data-list-item"
-                button
-                onClick={() => {
+                href={`?project=${file.id}`}
+                component="a"
+                target="_self"
+                /** onClick={() => {
                   handleClick({
                     display: file.name,
                     path: file.id,
                     type: DatasetType.Chem,
-                    uploaded: true, // indicates that file is already uploaded
+                    uploaded: true,
                   });
-                }}
+                }} */
               >
                 <ListItemText
                   primary={file.name}
@@ -104,7 +107,7 @@ export function UploadedFiles({ onChange, refresh }) {
                     </IconButton>
                   </ListItemSecondaryAction>
                 )}
-              </ListItem>
+              </ListItemButton>
             ))}
           </List>
         </Box>

--- a/src/ReactionCIMEApp.tsx
+++ b/src/ReactionCIMEApp.tsx
@@ -198,7 +198,7 @@ const ApplicationWrapper = connector(({ setMouseMoveFn, setMouseClickFn, resetVi
 
 export function ReactionCIMEApp() {
   const [context] = useState(new API<AppState>(null, createCIMERootReducer()));
-  context.store.dispatch(setItemLabel({ label: 'experiment', label_plural: 'experiments' }));
+  context.store.dispatch(setItemLabel({ label: 'experiment', labelPlural: 'experiments' }));
   const { user } = useVisynAppContext();
   const { clientConfig } = useVisynAppContext();
 

--- a/src/ReactionCIMEApp.tsx
+++ b/src/ReactionCIMEApp.tsx
@@ -71,12 +71,9 @@ const ApplicationWrapper = connector(({ setMouseMoveFn, setMouseClickFn, resetVi
 
   const onLoadProject = React.useCallback(
     (tableId: string) => {
-      console.log('load project' + tableId);
-
       new BackendCSVLoader().resolvePath(
         { path: tableId, uploaded: true },
         (dataset) => {
-          console.log(dataset);
           dispatch(RootActions.loadDataset(dataset));
         },
         cancellablePromise,

--- a/src/ReactionCIMEApp.tsx
+++ b/src/ReactionCIMEApp.tsx
@@ -1,10 +1,20 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { PSEContextProvider, API, Application, PluginRegistry, setItemLabel } from 'projection-space-explorer';
-import { connect, ConnectedProps } from 'react-redux';
+import {
+  PSEContextProvider,
+  API,
+  Application,
+  PluginRegistry,
+  setItemLabel,
+  usePSESelector,
+  RootActions,
+  useCancellablePromise,
+} from 'projection-space-explorer';
+import { connect, ConnectedProps, useDispatch } from 'react-redux';
 import { useVisynAppContext } from 'visyn_core';
 import { Anchor } from '@mantine/core';
 import { VisynApp, VisynHeader } from 'visyn_core/app';
+import { BrowserRouter, useSearchParams } from 'react-router-dom';
 import { LineUpContext } from './LineUpContext';
 import { LineUpTabPanel } from './Overrides/LineUpTabPanel';
 import { AppState, CIME4RViewActions, createCIMERootReducer } from './State/Store';
@@ -23,6 +33,7 @@ import { AddRegionExceptionMenuItem } from './Overrides/ContextMenu/AddRegionExc
 import { SetFiltersToItemFeatures } from './Overrides/ContextMenu/SetFiltersToItemFeatures';
 import vdsLogo from './assets/jku-vds-lab-logo.svg';
 import bayerLogo from './assets/bayer_logo.svg';
+import { BackendCSVLoader } from './Overrides/Dataset/BackendCSVLoader';
 
 PluginRegistry.getInstance().registerPlugin(new ReactionsPlugin());
 
@@ -45,11 +56,68 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 type Props = PropsFromRedux;
 
 const ApplicationWrapper = connector(({ setMouseMoveFn, setMouseClickFn, resetViews }: Props) => {
+  const loadedDataset = usePSESelector((state) => state.dataset);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const dispatch = useDispatch();
+  const { cancellablePromise } = useCancellablePromise();
+  const abortController = React.useMemo(() => new AbortController(), []);
+  const hasStartedRef = React.useRef(false);
+
   const startProjection = (msg: string) => {
     if (msg === 'init') {
       resetViews();
     }
   };
+
+  const onLoadProject = React.useCallback(
+    (tableId: string) => {
+      console.log('load project' + tableId);
+
+      new BackendCSVLoader().resolvePath(
+        { path: tableId, uploaded: true },
+        (dataset) => {
+          console.log(dataset);
+          dispatch(RootActions.loadDataset(dataset));
+        },
+        cancellablePromise,
+        null,
+        abortController,
+      );
+    },
+    [dispatch, abortController, cancellablePromise],
+  );
+
+  React.useEffect(() => {
+    if (hasStartedRef.current) {
+      return;
+    }
+    hasStartedRef.current = true;
+
+    const tableId = searchParams.get('project');
+
+    // If the application started with a tableId, try to load that
+    if (tableId) {
+      onLoadProject(tableId);
+    }
+  }, [searchParams, onLoadProject]);
+
+  React.useEffect(() => {
+    const tableId = loadedDataset?.info?.path;
+
+    if (!hasStartedRef.current) {
+      return;
+    }
+
+    setSearchParams((prev) => {
+      if (tableId) {
+        return new URLSearchParams({
+          project: tableId,
+        });
+      }
+
+      return prev;
+    });
+  }, [loadedDataset?.info, setSearchParams]);
 
   return (
     <Application
@@ -181,7 +249,9 @@ export function ReactionCIMEApp() {
     >
       {user ? (
         <PSEContextProvider context={context}>
-          <ApplicationWrapper />
+          <BrowserRouter>
+            <ApplicationWrapper />
+          </BrowserRouter>
         </PSEContextProvider>
       ) : null}
     </VisynApp>


### PR DESCRIPTION
The current behavior should be like this:
- The URL should show the currently loaded project
- When loading a new dataset, the page should refresh (to clean memory leaks etc and start a new session)
- A wrong id in the URL will not break anything and behave exactly like no url is present at all
- When opening the page with a valid URL, the dataset should automatically load