### PR TITLE
Many fixes related to memory usage when computing projections

### DIFF
--- a/cypress/component/component-health-check.cy.tsx
+++ b/cypress/component/component-health-check.cy.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { mount } from 'cypress/react';
 
 function MainApp() {
   return <div>hello world</div>;
@@ -7,7 +6,7 @@ function MainApp() {
 
 describe('Health check for Cypress component test', () => {
   it('should mount MainApp', () => {
-    mount(<MainApp />);
+    cy.mount(<MainApp />);
     cy.get('div').should('include.text', 'hello world');
   });
 });

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -19,7 +19,7 @@ import './commands';
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-import { mount } from 'cypress/react';
+import { mount } from 'cypress/react18';
 
 // Augment the Cypress namespace to include type definitions for
 // your custom command.

--- a/reaction_cime/reaction_cime_api.py
+++ b/reaction_cime/reaction_cime_api.py
@@ -824,9 +824,7 @@ class ProjectionThread(threading.Thread):
             self.current_step = self.params["iterations"]
             self.log("Save projection...")
             # update the coordinates in the dataset
-            start_time = time.time()
             self.cime_dbo.update_row_bulk(self.id, index, {"x": proj_data[:, 0], "y": proj_data[:, 1]})  # type: ignore
-            time.time() - start_time
             self.log("Finished!")
 
         except Exception as e:
@@ -1119,9 +1117,14 @@ class GetCoordinatesBody(BaseModel):
     ids: list[int]
 
 
+class GetCoordinatesResponseModel(BaseModel):
+    x: float
+    y: float
+
+
 @router.api_route("/get_coordinates/{id}", methods=["POST"])
-async def get_coordinates(id: str, data: GetCoordinatesBody):
-    return get_poi_df_from_db(id, data.ids)[0].loc[data.ids][["x", "y"]].to_dict("records")
+async def get_coordinates(id: str, data: GetCoordinatesBody) -> list[GetCoordinatesResponseModel]:
+    return get_poi_df_from_db(id, data.ids)[0].loc[data.ids][["x", "y"]].to_dict("records")  # type: ignore
 
 
 # different approach could have been with sockets: https://www.shanelynn.ie/asynchronous-updates-to-a-webpage-with-flask-and-socket-io/

--- a/reaction_cime/reaction_cime_api.py
+++ b/reaction_cime/reaction_cime_api.py
@@ -25,6 +25,7 @@ from fastapi.responses import StreamingResponse
 from flask import Blueprint, Response, abort, jsonify, request
 from flask.helpers import make_response
 from openTSNE import TSNE
+from pydantic import BaseModel
 from rdkit import Chem
 from rdkit.Chem import Draw
 from sklearn.decomposition import PCA
@@ -1112,6 +1113,15 @@ class ProjectionThread(threading.Thread):
 
         self.done = True
         self.log("client-side termination")
+
+
+class GetCoordinatesBody(BaseModel):
+    ids: list[int]
+
+
+@router.api_route("/get_coordinates/{id}", methods=["POST"])
+async def get_coordinates(id: str, data: GetCoordinatesBody):
+    return get_poi_df_from_db(id, data.ids)[0].loc[data.ids][["x", "y"]].to_dict("records")
 
 
 # different approach could have been with sockets: https://www.shanelynn.ie/asynchronous-updates-to-a-webpage-with-flask-and-socket-io/

--- a/src/Backend/ReactionCIMEBackend.ts
+++ b/src/Backend/ReactionCIMEBackend.ts
@@ -38,7 +38,7 @@ export class ReactionCIMEBackend {
     this.cache[key] = value;
   };
 
-  handleErrors = (response) => {
+  handleErrors = (response: Response): Response => {
     if (!response.ok) {
       throw Error(response.statusText);
     }
@@ -198,7 +198,7 @@ export class ReactionCIMEBackend {
     window.open(path);
   };
 
-  public project_dataset = async (filename: string, params: object, selected_feature_info: object, ids: string[], controller?) => {
+  public project_dataset = async (filename: string, params: object, selected_feature_info: object, ids: string[], controller?): Promise<Response> => {
     return fetch(`${this.baseUrl}/v2/project_dataset_async`, {
       ...this.fetchParams,
       method: 'POST',
@@ -214,9 +214,6 @@ export class ReactionCIMEBackend {
       .then((response) => {
         this.resetAggregationCache();
         return response;
-      })
-      .catch((error) => {
-        console.log(error);
       });
   };
 

--- a/src/Backend/ReactionCIMEBackend.ts
+++ b/src/Backend/ReactionCIMEBackend.ts
@@ -198,10 +198,13 @@ export class ReactionCIMEBackend {
     window.open(path);
   };
 
-  public project_dataset = async (filename: string, params: object, selected_feature_info: object, ids: string[], controller?): Promise<Response> => {
+  public project_dataset = async (filename: string, params: object, selected_feature_info: object, ids: number[], controller?): Promise<Response> => {
     return fetch(`${this.baseUrl}/v2/project_dataset_async`, {
       ...this.fetchParams,
       method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify({
         filename,
         params: JSON.stringify(params),
@@ -215,6 +218,21 @@ export class ReactionCIMEBackend {
         this.resetAggregationCache();
         return response;
       });
+  };
+
+  public get_coordinates = async (id: string, ids: number[]): Promise<Response> => {
+    return fetch(`${this.baseUrl}/v2/get_coordinates/${id}`, {
+      ...this.fetchParams,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ids,
+      }),
+    })
+      .then(this.handleErrors)
+      .then((r) => r.json());
   };
 
   public upload_csv_file = async (file, controller?): Promise<Project> => {

--- a/src/Overrides/Embeddings/RemoteEmbedding.ts
+++ b/src/Overrides/Embeddings/RemoteEmbedding.ts
@@ -16,7 +16,7 @@ export class RemoteEmbedding {
     protected params: object,
     protected embedding: IBaseProjection,
     protected selected_feature_info: object,
-    protected ids: string[],
+    protected ids: number[],
   ) {
     this.abort_controller = new AbortController();
     this.backend = new ReactionCIMEBackend(backendUrl, {});
@@ -74,7 +74,15 @@ export class RemoteEmbedding {
           ({ value, done } = await reader.read());
           if (done) {
             if (!hasSetEmbedding) {
-              callback_fn(this.embedding, this.current_steps, 'Embedding could not be loaded, please reload the application to see the new embedding.');
+              try {
+                // The embedding was not set automatically, so we fetch it here
+                // eslint-disable-next-line no-await-in-loop
+                const coordinates = await this.backend.get_coordinates(this.dataset, this.ids);
+                callback_fn(coordinates, this.current_steps, this.msg);
+              } catch (e) {
+                console.error('Error while fetching embedding', e);
+                callback_fn(this.embedding, this.current_steps, 'Embedding could not be loaded, please reload the application to see the new embedding.');
+              }
             }
           } else {
             try {

--- a/src/Overrides/Embeddings/RemoteEmbedding.ts
+++ b/src/Overrides/Embeddings/RemoteEmbedding.ts
@@ -35,7 +35,7 @@ export class RemoteEmbedding {
     let open = 0;
     const res = [];
     if (start === -1) {
-      return res;
+      return { res, rest: ss };
     }
     for (let i = start; i < ss.length; i++) {
       if (ss[i] === '{' && (i < 2 || ss.slice(i - 2, i) !== '\\"')) {
@@ -53,51 +53,55 @@ export class RemoteEmbedding {
         }
       }
     }
-    return res;
+    return { parsed: res, rest: ss.substring(start).trim() };
   };
 
   initializeFit(callback_fn: (emb, step, msg) => void) {
-    // https://stackoverflow.com/questions/62121310/how-to-handle-streaming-data-using-fetch
-    const readStream = async (reader) => {
-      let done;
-      let value;
-      /**
-       * True if the embedding has been set at least once, used to show the user an error if they should reload the page.
-       */
-      let hasSetEmbedding = false;
-      while (!done) {
-        // eslint-disable-next-line no-await-in-loop
-        ({ value, done } = await reader.read());
-        if (done) {
-          if (!hasSetEmbedding) {
-            callback_fn(this.embedding, this.current_steps, 'Embedding could not be loaded, please reload the application to see the new embedding.');
-          }
-        } else {
-          try {
-            const valueString = new TextDecoder().decode(value);
-            // In case multiple JSON objects are received at once, we need to parse them all
-            const splitValue = this.jsonParseMultiple(valueString);
-            if (splitValue.length === 0) continue;
-            const resObj = splitValue[splitValue.length - 1];
-            if (parseInt(resObj.step, 10)) this.current_steps = parseInt(resObj.step, 10);
-            if (resObj.emb && resObj.emb.length > 0) {
-              hasSetEmbedding = true;
-              this.embedding = resObj.emb;
+    this.backend
+      .project_dataset(this.dataset, this.params, this.selected_feature_info, this.ids, this.abort_controller)
+      .then(async (response) => {
+        // https://stackoverflow.com/questions/62121310/how-to-handle-streaming-data-using-fetch
+        const reader = response.body.getReader();
+        let done;
+        let value;
+        let previousValue = '';
+        /**
+         * True if the embedding has been set at least once, used to show the user an error if they should reload the page.
+         */
+        let hasSetEmbedding = false;
+        while (!done) {
+          // eslint-disable-next-line no-await-in-loop
+          ({ value, done } = await reader.read());
+          if (done) {
+            if (!hasSetEmbedding) {
+              callback_fn(this.embedding, this.current_steps, 'Embedding could not be loaded, please reload the application to see the new embedding.');
             }
-            if (resObj.msg) this.msg = resObj.msg;
-            callback_fn(this.embedding, this.current_steps, this.msg);
-          } catch (error) {
-            console.error('Error while projecting', error);
-            callback_fn(this.embedding, this.current_steps, this.msg);
+          } else {
+            try {
+              const valueString = new TextDecoder().decode(value);
+              // In case multiple JSON objects are received at once, we need to parse them all
+              const { parsed: splitValue, rest } = this.jsonParseMultiple(previousValue + valueString);
+              if (splitValue.length === 0) continue;
+              previousValue = rest;
+              const resObj = splitValue[splitValue.length - 1];
+              if (parseInt(resObj.step, 10)) this.current_steps = parseInt(resObj.step, 10);
+              if (resObj.emb && resObj.emb.length > 0) {
+                hasSetEmbedding = true;
+                this.embedding = resObj.emb;
+              }
+              if (resObj.msg) this.msg = resObj.msg;
+              callback_fn(this.embedding, this.current_steps, this.msg);
+            } catch (error) {
+              console.error('Error while projecting', error);
+              callback_fn(this.embedding, this.current_steps, this.msg);
+            }
           }
         }
-      }
-    };
-
-    this.backend.project_dataset(this.dataset, this.params, this.selected_feature_info, this.ids, this.abort_controller).then((response) => {
-      const reader = response.body.getReader();
-      readStream(reader);
-    });
+      })
+      .catch((e) => {
+        console.error('Error while projecting', e);
+        callback_fn(this.embedding, this.current_steps, `Error while projecting: ${e}`);
+      });
   }
 
   abort(callback) {

--- a/src/Overrides/Embeddings/remote.worker.ts
+++ b/src/Overrides/Embeddings/remote.worker.ts
@@ -1,37 +1,26 @@
+/* eslint-disable no-restricted-globals */
 // import "regenerator-runtime/runtime";
 
 import { RemoteEmbedding } from './RemoteEmbedding';
 
-/* eslint-disable-next-line no-restricted-globals */
-const ctx = self;
-
 const callbackFnStep = (emb, step, msg) => {
-  ctx.postMessage({ messageType: 'step', embedding: emb, step, msg });
+  self.postMessage({ messageType: 'step', embedding: emb, step, msg });
 };
 const callbackFnTerminated = () => {
-  ctx.postMessage({ messageType: 'terminated' });
+  self.postMessage({ messageType: 'terminated' });
 };
 
-ctx.addEventListener(
-  'message',
-  function (e) {
-    if (e.data.messageType === 'init') {
-      const embedding = new RemoteEmbedding(e.data.backendUrl, e.data.path, e.data.params, e.data.init_coordinates, e.data.selected_feature_info, e.data.ids);
-      embedding.initializeFit(callbackFnStep);
-      // embedding.step(callback_fn)
+let embedding: RemoteEmbedding | null;
 
-      // @ts-ignore
-      ctx.embedding = embedding;
+self.addEventListener(
+  'message',
+  (e) => {
+    if (e.data.messageType === 'init') {
+      embedding = new RemoteEmbedding(e.data.backendUrl, e.data.path, e.data.params, e.data.init_coordinates, e.data.selected_feature_info, e.data.ids);
+      embedding.initializeFit(callbackFnStep);
     } else if (e.data.messageType === 'abort') {
-      // @ts-ignore
-      const { embedding } = ctx;
-      embedding.abort(callbackFnTerminated);
+      embedding?.abort(callbackFnTerminated);
     }
-    // else {
-    //     // @ts-ignore
-    //     const embedding = ctx.embedding;
-    //     embedding.step(callback_fn)
-    // }
   },
   false,
 );


### PR DESCRIPTION
Closes https://github.com/jku-vds-lab/reaction-cime/issues/94, https://github.com/jku-vds-lab/reaction-cime/issues/96

### Developer Checklist (Definition of Done)

**Issue**

- [x] All acceptance criteria from the issue are met
- [x] Tested in latest Chrome/Firefox

**UI/UX/Vis**

- [ ] Requires UI/UX/Vis review
  - [ ] Reviewer(s) are notified (_tag assignees_)
  - [ ] Review has occurred (_link to notes_)
  - [ ] Feedback is included in this PR
  - [ ] Reviewer(s) approve of concept and design

**Code**

- [x] Branch is up-to-date with the branch to be merged with, i.e., develop
- [x] Code is cleaned up and formatted
- [ ] Unit tests are written (frontend/backend if applicable)
- [ ] Integration tests are written (if applicable)

**PR**

- [x] Descriptive title for this pull request is provided (will be used for release notes later)
- [x] Reviewer and assignees are defined
- [x] Add type label (e.g., *bug*, *feature*) to this pull request
- [x] Add release label (e.g., `release: minor`) to this PR following [semver](https://semver.org/)
- [x] The PR is connected to the corresponding issue (via `Closes #...`)
- [x] [Summary of changes](#summary-of-changes) is written


### Summary of changes

- Drastically change the way how datasets are projected. The main issue is loading the entire dataframe. How do we get around that?
  - Enable chunked processing of columns to determine normalization functions (i.e. min/max, categories, ...). These are returned as closured variables in `featurizers`.
  - If we determine the dataset is too large, we precompute incremental PCA by using chunked parts of the data
    - If that already yields only 2 components, we return that as our coordinates
  - Then, we compute the actual projections on the PCA components/features
  - If gowers distance is used, we only support datasets with max 10k rows, as the distance matrix explodes quadratically.
  - If the dataset fits in memory, we use the actual projection
- This basically reduces memory usage by order of magnitudes for large datasets (i.e. 10GB+ to 1-2GB) for 300k rows.

### Screenshots
Result of UMAP of dataset with 315k rows on feature sulfonyl (157 features). Took around 15min.

![image](https://user-images.githubusercontent.com/51900829/233599699-aaf6701f-0283-4440-a5d3-2927a34ae379.png)

### Additional notes for the reviewer(s)

-  
Thanks for creating this pull request 🤗
